### PR TITLE
fix(render): render process cannot import electron

### DIFF
--- a/config-overrides.js
+++ b/config-overrides.js
@@ -17,7 +17,13 @@ const sourceMap = () => config => {
   return config;
 }
 
+const addWebpackTarget = target => config => {
+  config.target = target
+  return config
+}
+
 module.exports = override(
+  addWebpackTarget('electron-renderer'),
   sourceMap(),
   isElectron && addWebpackExternals({
     "agora-electron-sdk": "commonjs2 agora-electron-sdk"


### PR DESCRIPTION
If used in the rendering process:
```typescript
import { ipcRenderer } from "electron";
import fs from "fs";
```

The code will report an error because webpack defaults to `web`, not `electron-renderer`. As a result, the compiled code cannot use the API of `electron` and `nodejs`